### PR TITLE
fix: use bar-scaled icon size so icon scales with the system

### DIFF
--- a/DisplayManager.qml
+++ b/DisplayManager.qml
@@ -80,7 +80,7 @@ PluginComponent {
             spacing: Theme.spacingS
             DankIcon {
                 name: "desktop_windows"
-                size: Theme.iconSize
+                size: root.iconSize
                 color: Theme.surfaceVariantText
                 anchors.verticalCenter: parent.verticalCenter
             }
@@ -92,7 +92,7 @@ PluginComponent {
             spacing: Theme.spacingXS
             DankIcon {
                 name: "desktop_windows"
-                size: Theme.iconSize
+                size: root.iconSize
                 color: root.monitors.some(m => m.enabled) ? Theme.primary : Theme.surfaceVariantText
                 anchors.horizontalCenter: parent.horizontalCenter
             }

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
   "id": "displayManager",
   "name": "Display Manager",
   "description": "A widget to turn on/off and adjust brightness of multiple displays in Niri.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "felri",
   "type": "widget",
   "component": "./DisplayManager.qml",


### PR DESCRIPTION
## Summary

The Display Manager bar pill icons used the raw \`Theme.iconSize\` constant (a fixed 24px). This meant the icon **did not scale** with the bar thickness, nor with the user's \`maximizeWidgetIcons\` or \`iconScale\` settings — so it appeared larger than every other DMS bar widget and ignored the system's icon-scaling configuration.

## Fix

Switch the bar pill \`DankIcon\` declarations from \`size: Theme.iconSize\` to \`size: root.iconSize\` (exposed by \`PluginComponent\`, which calls \`Theme.barIconSize(barThickness, -4, maximizeWidgetIcons, iconScale)\`).

This **allows the icon to scale with the system**, consistent with all built-in DMS bar widgets (Battery, ClipboardButton, ColorPicker, ControlCenterButton, CpuMonitor, etc.) and the dankKDEConnect plugin.

## Changes
- \`DisplayManager.qml\`: both \`horizontalBarPill\` and \`verticalBarPill\` icons now use \`root.iconSize\` instead of \`Theme.iconSize\`.
- \`plugin.json\`: version bump \`1.0.0\` → \`1.0.1\`.